### PR TITLE
Added support for disabled items

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8">
     <title>ul2select</title>
-
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="jquery.ul2select.js"></script>
     <link rel="stylesheet" href="ul2select.css" media="all">
 
   </head>
@@ -16,6 +17,19 @@
     </li>
     <li data-value="option_2">
       <span>Option 2</span>
+    </li>
+  </ul>
+
+  <h2>Basic example with disabled items</h2>
+  <ul id="demo_disabled" class="demo">
+    <li data-value="option_1">
+      <span>Option 1</span>
+    </li>
+    <li data-value="option_2">
+      <span>Option 2</span>
+    </li>
+    <li class="disabled" data-value="option_3">
+      <span>Option 3</span>
     </li>
   </ul>
 
@@ -105,6 +119,11 @@
       $('#demo_basic').ul2select();
       $('#demo_basic').change(function() {
           console.log('basic ul changed, value: ' + $(this).data('value'));
+      });
+
+      $('#demo_disabled').ul2select();
+      $('#demo_disabled').change(function() {
+          console.log('ul with disabled items changed, value: ' + $(this).data('value'));
       });
 
       $('#no_novalue').ul2select({

--- a/jquery.ul2select.js
+++ b/jquery.ul2select.js
@@ -17,6 +17,7 @@
          * @param li
          */
         function selectLi(li, doTrigger) {
+            if (li.hasClass('disabled')) return;
             $ul = li.parent('ul');
 
             $allOptions = $ul.children('li:not(.init)');
@@ -111,7 +112,7 @@
 
                 // register click function on li.init a
                 // preventing it to navigate
-                $ul.on("click", "li.init a", function(e) {
+                $ul.on("click", "li.init a, li.disabled a", function(e) {
                     e.preventDefault();
                 });
 
@@ -162,19 +163,19 @@
                     switch(e.keyCode) {
                         case 38:
                             // user pressed 'up'
-                            if (selected.prev().length == 0) {
+                            if (selected.prev(':not(.disabled)').length == 0) {
                                 selected.siblings().last().addClass("selected");
                             } else {
-                                selected.prev().addClass("selected");
+                                selected.prev(':not(.disabled)').addClass("selected");
                             }
 
                             break;
                         case 40:
                             // user pressed 'down'
-                            if (selected.next().length == 0) {
+                            if (selected.next(':not(.disabled)').length == 0) {
                                 selected.siblings().first().addClass("selected");
                             } else {
-                                selected.next().addClass("selected");
+                                selected.next(':not(.disabled)').addClass("selected");
                             }
 
                             break;

--- a/ul2select.css
+++ b/ul2select.css
@@ -7,15 +7,16 @@ ul.ul2select li label { display: block; padding: 10px 0; line-height: 2.1em; cur
 ul.ul2select li input { display: none; }
 ul.ul2select li.init:after { font-size: 16px; top: 17px; color: #DDD; }
 ul.ul2select li:not(.init) { width: 100%; float: left; display: none; background: #FFF; cursor: pointer;}
+ul.ul2select li.disabled { cursor: default; text-decoration: line-through; color: #888; }
 ul.ul2select.open { position: relative; z-index: 1000; background: #FFF; }
 ul.ul2select.open li:not(.init) { display: block }
-ul.ul2select li:not(.init):hover,
-ul.ul2select li.selected:not(.init) { background: #333; color: #FFF; }
-ul.ul2select li:not(.init):hover label,
-ul.ul2select li.selected:not(.init) label,
-ul.ul2select li:not(.init):hover span,
-ul.ul2select li.selected:not(.init) span { background: #333; color: #FFF; }
-ul.ul2select li:not(.init) label:hover { color: #333;  }
+ul.ul2select li:not(.init):not(.disabled):hover,
+ul.ul2select li.selected:not(.init):not(.disabled) { background: #333; color: #FFF; }
+ul.ul2select li:not(.init):not(.disabled):hover label,
+ul.ul2select li.selected:not(.init):not(.disabled) label,
+ul.ul2select li:not(.init):not(.disabled):hover span,
+ul.ul2select li.selected:not(.init):not(.disabled) span { background: #333; color: #FFF; }
+ul.ul2select li:not(.init):not(.disabled) label:hover { color: #333;  }
 ul.ul2select li.init { background: #FFF; color: #333; cursor: pointer; }
 ul.ul2select li.init:after { content: '\e634'; position: absolute; right: 10px; top: 0; font-size: 20px; color: red; }
 ul.ul2select li.init label { line-height: 2.3em; color: #333; }


### PR DESCRIPTION
To disable an item, the class 'disabled' should be added to the `<li>`. The item will not be selectable by either mouse or keyboard navigation.

Signed-off-by: Leon Boot leon@nedbase.nl
